### PR TITLE
Fixes for .gitignore, package.json and .sass-lint.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,4 +70,5 @@ static/js/dist
 static/js/cookie-policy.js
 static/js/global-nav.js
 static/js/forms.js
+static/js/modals.js
 static/js/utils.js

--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -37,7 +37,6 @@ rules:
   no-misspelled-properties: 2
   no-trailing-whitespace: 2
   no-trailing-zero: 2
-  no-url-protocols: 2
 
   # Line Spacing
   one-declaration-per-line: 2
@@ -45,7 +44,6 @@ rules:
   single-line-per-selector: 2
 
   # Disallows
-  no-ids: 2
   no-qualifying-elements:
     - 2
     - allow-element-with-attribute: true
@@ -66,8 +64,6 @@ rules:
   hex-length: 2
   hex-notation: 2
   indentation: 2
-  leading-zero: 2
-  nesting-depth: 2
   pseudo-element: 2
   quotes: 0
   url-quotes: 2

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "scripts": {
     "start": "yarn build && yarn serve",
     "lint-python": "flake8 webapp && black --check --line-length 79 webapp",
-    "lint-scss": "sass-lint _sass/**/*.scss --verbose --no-exit",
+    "lint-scss": "sass-lint sass/**/*.scss --verbose --no-exit",
     "test": "yarn run lint-scss && yarn run lint-python",
-    "watch": "watch -p '_sass/**/*.scss' -c 'yarn run build'",
+    "watch": "watch -p 'sass/**/*.scss' -c 'yarn run build'",
     "build": "yarn run build-css && yarn run build-js",
     "build-css": "sass sass/main.scss static/css/main.css --load-path=node_modules --style=compressed && postcss --use autoprefixer --replace static/css/**/*.css",
     "build-intl-tel-input-utils": "cp node_modules/intl-tel-input/build/js/utils.js static/js",


### PR DESCRIPTION
## Done

- Added static/js/modals.js file to .gitignore (it is automatically generated by the build.js script)
- Fixed references to the sass folder in package.json
- Allowed url-protocols, leading-zero, nesting-depth and ids in .sass-lint.yml file