### PR TITLE
WD-7839 - remove Nvidia logo from the landing page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -266,18 +266,6 @@
           </div>
           <div class="p-logo-section__item">
             {{ image (
-              url="https://assets.ubuntu.com/v1/1e1dfada-nvidia-logo%20@372px.png",
-              alt="nvidia",
-              width="372",
-              height="372",
-              hi_def=True,
-              loading="auto|lazy",
-              attrs={"class": "p-logo-section__logo"}
-              ) | safe
-            }}
-          </div>
-          <div class="p-logo-section__item">
-            {{ image (
               url="https://assets.ubuntu.com/v1/a4f5893f-intel-new-logo%20@372px.png",
               alt="Intel",
               width="372",


### PR DESCRIPTION
## Done

Removed Nvidia logo from the landing page

## QA

- [demo link](https://microcloud-is-45.demos.haus/)
- [copy doc](https://docs.google.com/document/d/17iBbFCINLYjPBOYWpgoq9SreyYNkR0Sb5jgx5iTo6MA/edit#heading=h.8w7t3ud1kp3d)
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check that Nvidia logo is removed

## Issue / Card
[WD-7839](https://warthogs.atlassian.net/browse/WD-7839)

## Screenshots


[WD-7839]: https://warthogs.atlassian.net/browse/WD-7839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ